### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,7 +253,8 @@ app.delete('/items/:id', verifyToken, (req, res) => {
             res.json({ message: 'User deleted successfully.', itemId: id });
         });
     } catch (E) {
-        res.status(400).send(E);
+        console.error('Exception in DELETE /items/:id:', E);
+        res.status(500).json({ error: 'Internal server error.' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/5](https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/5)

To fix the problem:
- In the `catch` block at line 255 for the DELETE `/items/:id` route, do not send the exception object `E` directly to the user.
- Instead, log the full error (ideally with stack trace) to the server console or a log file for developers.
- Respond to the user with a generic error message, such as "Internal server error" or "An error occurred" with an appropriate HTTP status code.
- The response body should not include any sensitive data or stack trace information.

Implementation:
- Replace `res.status(400).send(E);` with:
    - A log statement referencing `E` (e.g. `console.error()`).
    - A generic error response, such as `res.status(500).json({ error: 'Internal server error.' });`.
- No additional dependencies are needed since `console.error` is sufficient.
- Only lines within the delete route's catch block in app.js (lines 255-257) need modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
