### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,7 +154,8 @@ app.post('/users/insert/', verifyToken, (req, res) => {
             res.status(201).json({ message: 'User created successfully.', itemId: this.lastID });
         });
     } catch (E) {
-        res.status(400).send(E);
+        console.error(E);
+        res.status(400).send("Bad Request.");
     }
 });
 
@@ -170,7 +171,8 @@ app.get('/users/view/', verifyToken, (req, res) => {
             res.status(201).json({ "data": rows });
         });
     } catch (E) {
-        res.status(400).send(E);
+        console.error(E);
+        res.status(400).send("Bad Request.");
     }
 });
 
@@ -193,7 +195,8 @@ app.get('/users/view/:id', verifyToken, (req, res) => {
             res.json({ "data": rows });
         });
     } catch (E) {
-        res.status(400).send(E);
+        console.error(E);
+        res.status(400).send("Bad Request.");
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/2](https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/2)

To fix the problem, do not send the error object `E` directly to the user. Instead, return a generic error message on the response, providing minimal and non-sensitive information. Log the full error internally for diagnostics. Specifically, replace `res.status(400).send(E);` (and any similar statements) with a generic response such as `res.status(400).send("Bad Request")` or, for internal errors, `"Internal server error"`. Optionally, internally log the actual error (e.g., using `console.error(E)` or a logging library). This needs to be done in each catch block where errors are sent unsanitized, so lines 157 and 173 in app.js. No new imports are required; standard node `console.error` is adequate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
