### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through a stack trace

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,8 @@ app.put('/users/modify/:id', verifyToken, (req, res) => {
             res.json({ message: 'User updated successfully.', itemId: id });
         });
     } catch (E) {
-        res.status(400).send(E);
+        console.error('Exception in PUT /users/modify/:id:', E);
+        res.status(500).json({ error: 'Internal server error.' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/4](https://github.com/kavineksith/Simply-Identity-Management-API/security/code-scanning/4)

To fix this problem, avoid sending the error object (which may contain stack trace information) back to the user. Instead, log the error on the server for developer reference and send a generic error message in the HTTP response. This will prevent exposure of sensitive internal details, while maintaining information for debugging purposes. Specifically, on line 234, replace `res.status(400).send(E);` with two steps: log the error server-side using `console.error(E);`, then respond with a generic message such as `res.status(500).json({ error: 'Internal server error.' });`. This change is consistent with the pattern used elsewhere in the codebase.

Only lines within the shown `/users/modify/:id` handler (lines 233-235) are affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
